### PR TITLE
Add compatibility with node versions > 18

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         os: [ubuntu-latest, windows-2019, windows-latest, macos-latest]
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
-        "nan": "~2.16.0",
+        "nan": "^2.17.0",
         "xml2js": "^0.4.23"
       },
       "devDependencies": {
@@ -2049,9 +2049,9 @@
       "dev": true
     },
     "node_modules/nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "node_modules/nanoid": {
       "version": "3.3.1",
@@ -4615,9 +4615,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
-      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "nanoid": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "bindings": "^1.5.0",
-    "nan": "~2.16.0",
+    "nan": "^2.17.0",
     "xml2js": "^0.4.23"
   },
   "devDependencies": {

--- a/src/mbus-master.cc
+++ b/src/mbus-master.cc
@@ -1,5 +1,6 @@
 #include "mbus-master.h"
 #include "util.h"
+#include "node.h"
 
 #ifdef _WIN32
 #define __PRETTY_FUNCTION__ __FUNCSIG__
@@ -55,7 +56,11 @@ NAN_MODULE_INIT(MbusMaster::Init) {
 
     v8::Local<v8::Function> function = Nan::GetFunction(tpl).ToLocalChecked();
     constructor.Reset(function);
+#if NODE_MAJOR_VERSION >= 19
+    v8::Local<v8::Context> context = target->GetCreationContext().ToLocalChecked();
+#else
     v8::Local<v8::Context> context = target->CreationContext();
+#endif
     target->Set(context, Nan::New("MbusMaster").ToLocalChecked(), function);
 }
 

--- a/src/mbus-master.cc
+++ b/src/mbus-master.cc
@@ -56,11 +56,7 @@ NAN_MODULE_INIT(MbusMaster::Init) {
 
     v8::Local<v8::Function> function = Nan::GetFunction(tpl).ToLocalChecked();
     constructor.Reset(function);
-#if NODE_MAJOR_VERSION >= 19
     v8::Local<v8::Context> context = target->GetCreationContext().ToLocalChecked();
-#else
-    v8::Local<v8::Context> context = target->CreationContext();
-#endif
     target->Set(context, Nan::New("MbusMaster").ToLocalChecked(), function);
 }
 

--- a/src/mbus-master.cc
+++ b/src/mbus-master.cc
@@ -56,7 +56,11 @@ NAN_MODULE_INIT(MbusMaster::Init) {
 
     v8::Local<v8::Function> function = Nan::GetFunction(tpl).ToLocalChecked();
     constructor.Reset(function);
-    v8::Local<v8::Context> context = target->GetCreationContext().ToLocalChecked();
+#if NODE_MAJOR_VERSION > 18
+    v8::Local<v8::Context> context = target->GetCreationContextChecked();
+#else
+    v8::Local<v8::Context> context = target->CreationContext();
+#endif
     target->Set(context, Nan::New("MbusMaster").ToLocalChecked(), function);
 }
 

--- a/src/mbus-master.cc
+++ b/src/mbus-master.cc
@@ -1,6 +1,5 @@
 #include "mbus-master.h"
 #include "util.h"
-#include "node.h"
 
 #ifdef _WIN32
 #define __PRETTY_FUNCTION__ __FUNCSIG__
@@ -56,11 +55,7 @@ NAN_MODULE_INIT(MbusMaster::Init) {
 
     v8::Local<v8::Function> function = Nan::GetFunction(tpl).ToLocalChecked();
     constructor.Reset(function);
-#if NODE_MAJOR_VERSION >= 19
-    v8::Local<v8::Context> context = target->GetCreationContext().ToLocalChecked();
-#else
     v8::Local<v8::Context> context = target->CreationContext();
-#endif
     target->Set(context, Nan::New("MbusMaster").ToLocalChecked(), function);
 }
 


### PR DESCRIPTION
Hi there :)

Trying to use the project with Node versions greater than 18, the build process currently fails (c.f. https://github.com/eclipse-thingweb/node-wot/issues/1004). This PR tries to provide a fix for the issue, updating the `nan` dependency to the latest version and adding a check for the node version in `mbus-master.cc` (since there apparently has been an API change in V8). To ensure that the project builds with all currently supported Node versions, the GitHub Actions workflow is updated accordingly.

I hope that the changes are reasonable – otherwise let me know if there is anything to improve :)